### PR TITLE
🛡️ Sentinel: Fix loose ENUM validation in agendamento form

### DIFF
--- a/com_crm/administrator/forms/agendamento.xml
+++ b/com_crm/administrator/forms/agendamento.xml
@@ -14,6 +14,12 @@
             <option value="sms">SMS</option>
         </field>
         <field name="inicio_em" type="calendar" label="COM_CRM_START_DATE" description="" size="40" />
-        <field name="status_job" type="text" label="COM_CRM_STATUS" description="" size="40" maxlength="20" filter="string" />
+        <field name="status_job" type="list" label="COM_CRM_STATUS" description="" default="agendado">
+            <option value="agendado">COM_CRM_STATUS_JOB_AGENDADO</option>
+            <option value="em_execucao">COM_CRM_STATUS_JOB_EM_EXECUCAO</option>
+            <option value="finalizado">COM_CRM_STATUS_JOB_FINALIZADO</option>
+            <option value="pausado">COM_CRM_STATUS_JOB_PAUSADO</option>
+            <option value="erro">COM_CRM_STATUS_JOB_ERRO</option>
+        </field>
     </fieldset>
 </form>

--- a/com_crm/administrator/language/en-GB/en-GB.com_crm.ini
+++ b/com_crm/administrator/language/en-GB/en-GB.com_crm.ini
@@ -104,3 +104,10 @@ COM_CRM_IMPORTARQUIVO_ERROR_FILE_NOT_FOUND="CSV file not found on the server."
 COM_CRM_IMPORTARQUIVO_ERROR_CANNOT_OPEN_FILE="Could not open the CSV file for reading."
 COM_CRM_IMPORT_SUCCESS_MESSAGE="%s leads imported successfully, %s failed."
 COM_CRM_IMPORT_FAILED_MESSAGE="Import process failed"
+
+; --- Agendamentos ---
+COM_CRM_STATUS_JOB_AGENDADO="Scheduled"
+COM_CRM_STATUS_JOB_EM_EXECUCAO="Running"
+COM_CRM_STATUS_JOB_FINALIZADO="Finished"
+COM_CRM_STATUS_JOB_PAUSADO="Paused"
+COM_CRM_STATUS_JOB_ERRO="Error"

--- a/com_crm/administrator/language/pt-BR/pt-BR.com_crm.ini
+++ b/com_crm/administrator/language/pt-BR/pt-BR.com_crm.ini
@@ -103,3 +103,10 @@ COM_CRM_IMPORTARQUIVO_ERROR_FILE_NOT_FOUND="Arquivo CSV não encontrado no servi
 COM_CRM_IMPORTARQUIVO_ERROR_CANNOT_OPEN_FILE="Não foi possível abrir o arquivo CSV para leitura."
 COM_CRM_IMPORT_SUCCESS_MESSAGE="%s leads importados com sucesso, %s falharam."
 COM_CRM_IMPORT_FAILED_MESSAGE="O processo de importação falhou"
+
+; --- Agendamentos ---
+COM_CRM_STATUS_JOB_AGENDADO="Agendado"
+COM_CRM_STATUS_JOB_EM_EXECUCAO="Em Execução"
+COM_CRM_STATUS_JOB_FINALIZADO="Finalizado"
+COM_CRM_STATUS_JOB_PAUSADO="Pausado"
+COM_CRM_STATUS_JOB_ERRO="Erro"

--- a/tests/verify_agendamento_form.php
+++ b/tests/verify_agendamento_form.php
@@ -1,0 +1,64 @@
+<?php
+// Mock Joomla environment enough to load SimpleXML
+define('_JEXEC', 1);
+
+$xmlFile = __DIR__ . '/../com_crm/administrator/forms/agendamento.xml';
+
+if (!file_exists($xmlFile)) {
+    echo "Error: XML file not found at $xmlFile\n";
+    exit(1);
+}
+
+$xml = simplexml_load_file($xmlFile);
+if (!$xml) {
+    echo "Error: Failed to parse XML\n";
+    exit(1);
+}
+
+// Find status_job field
+$statusJobField = null;
+foreach ($xml->fieldset->field as $field) {
+    if ((string)$field['name'] === 'status_job') {
+        $statusJobField = $field;
+        break;
+    }
+}
+
+if (!$statusJobField) {
+    echo "Error: Field 'status_job' not found\n";
+    exit(1);
+}
+
+if ((string)$statusJobField['type'] !== 'list') {
+    echo "Error: Field 'status_job' is not type 'list'. Found: " . $statusJobField['type'] . "\n";
+    exit(1);
+}
+
+echo "Success: Field 'status_job' is type 'list'\n";
+
+// Verify options
+$expectedOptions = [
+    'agendado',
+    'em_execucao',
+    'finalizado',
+    'pausado',
+    'erro'
+];
+
+$foundOptions = [];
+foreach ($statusJobField->option as $option) {
+    $foundOptions[] = (string)$option['value'];
+}
+
+$missing = array_diff($expectedOptions, $foundOptions);
+$extra = array_diff($foundOptions, $expectedOptions);
+
+if (!empty($missing) || !empty($extra)) {
+    echo "Error: Options mismatch.\n";
+    echo "Expected: " . implode(', ', $expectedOptions) . "\n";
+    echo "Found: " . implode(', ', $foundOptions) . "\n";
+    exit(1);
+}
+
+echo "Success: All expected options are present.\n";
+exit(0);


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix loose ENUM validation in agendamento form

**Vulnerability:** The `status_job` field in the Agendamento (Scheduling) form was defined as a `text` input, allowing users to submit any string value. This violated the database schema which uses an `ENUM` and could lead to invalid states or errors.
**Impact:** Users could bypass business logic by setting invalid job statuses (e.g., bypassing state transitions).
**Fix:** Changed the field type to `list` in `agendamento.xml` and defined the allowed options matching the database ENUM. Added translation keys.
**Verification:** Run `php tests/verify_agendamento_form.php` to confirm the field is now a list with the correct options.

---
*PR created automatically by Jules for task [17019570888361026389](https://jules.google.com/task/17019570888361026389) started by @jorgedemetrio*