### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Lead Form

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Insecure Direct Object Reference / ID Truncation
 **Learning:** Joomla's legacy `(int)` casting in routers silently corrupts UUIDs (truncating them to 0) and potentially allows "dirty" IDs (e.g., `123-junk`).
 **Prevention:** Use strict validation (Numeric OR UUID Regex) instead of casting to `(int)` when handling IDs in `ParseRoute`, especially for components supporting UUIDs.
+
+## 2026-01-28 - [Joomla 3 Form Security - URL]
+**Vulnerability:** `type="url"` fields in XML forms using `filter="string"` allows Javascript URI schemes (`javascript:alert(1)`).
+**Learning:** `filter="string"` only strips HTML tags but preserves the content. It does not validate or sanitize the protocol. `filter="url"` is required to sanitize the URL (checking protocol, escaping).
+**Prevention:** Always pair `type="url"` with `filter="url"` in Joomla XML forms to prevent Stored XSS via dangerous protocols.

--- a/com_crm/administrator/forms/lead.xml
+++ b/com_crm/administrator/forms/lead.xml
@@ -7,7 +7,7 @@
         <field name="cnpj" type="text" label="COM_CRM_LEAD_CNPJ_LABEL" size="20" maxlength="14" filter="string" />
         <field name="email" type="email" label="COM_CRM_LEAD_EMAIL_LABEL" required="true" size="40" maxlength="255" filter="string" />
         <field name="telefone1" type="text" label="COM_CRM_LEAD_TELEFONE1_LABEL" size="20" maxlength="30" filter="string" />
-        <field name="site" type="url" label="COM_CRM_LEAD_SITE_LABEL" size="40" maxlength="255" filter="string" />
+        <field name="site" type="url" label="COM_CRM_LEAD_SITE_LABEL" size="40" maxlength="255" filter="url" />
         <field name="state" type="list" label="JSTATUS" default="1">
             <option value="1">JPUBLISHED</option>
             <option value="0">JUNPUBLISHED</option>

--- a/tests/verify_lead_xml_security.php
+++ b/tests/verify_lead_xml_security.php
@@ -1,0 +1,48 @@
+<?php
+// tests/verify_lead_xml_security.php
+
+$xmlFile = __DIR__ . '/../com_crm/administrator/forms/lead.xml';
+
+if (!file_exists($xmlFile)) {
+    echo "Error: lead.xml not found at $xmlFile\n";
+    exit(1);
+}
+
+$xml = simplexml_load_file($xmlFile);
+
+if ($xml === false) {
+    echo "Error: Failed to parse lead.xml\n";
+    exit(1);
+}
+
+$found = false;
+$secure = false;
+
+// Traverse fields to find 'site'
+foreach ($xml->fieldset as $fieldset) {
+    foreach ($fieldset->field as $field) {
+        if ((string)$field['name'] === 'site') {
+            $found = true;
+            $filter = (string)$field['filter'];
+            echo "Found 'site' field. Current filter: '$filter'\n";
+
+            if ($filter === 'url') {
+                $secure = true;
+            }
+            break 2;
+        }
+    }
+}
+
+if (!$found) {
+    echo "Error: 'site' field not found in lead.xml\n";
+    exit(1);
+}
+
+if ($secure) {
+    echo "SUCCESS: 'site' field is using secure filter='url'.\n";
+    exit(0);
+} else {
+    echo "FAILURE: 'site' field is NOT using secure filter='url'. Potential XSS vulnerability.\n";
+    exit(1);
+}


### PR DESCRIPTION
🛡️ Sentinel Security Fix

**Vulnerability:** Stored XSS via `site` field in Lead Form.
**Severity:** HIGH
**Impact:** Administrators viewing leads could be exposed to XSS attacks if a malicious lead (e.g., imported via API/CSV) injects a `javascript:` URI into the site field. `filter="string"` only strips HTML tags but allows dangerous protocols.
**Fix:** Changed filter to `url` which sanitizes and validates the URL protocol.
**Verification:** Added `tests/verify_lead_xml_security.php` to verify the XML configuration.

---
*PR created automatically by Jules for task [1914411364448135528](https://jules.google.com/task/1914411364448135528) started by @jorgedemetrio*