### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rate limiting to Optout endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,8 @@
 **Vulnerability:** `type="url"` fields in XML forms using `filter="string"` allows Javascript URI schemes (`javascript:alert(1)`).
 **Learning:** `filter="string"` only strips HTML tags but preserves the content. It does not validate or sanitize the protocol. `filter="url"` is required to sanitize the URL (checking protocol, escaping).
 **Prevention:** Always pair `type="url"` with `filter="url"` in Joomla XML forms to prevent Stored XSS via dangerous protocols.
+
+## 2025-05-23 - [Rate Limiting Pattern]
+**Vulnerability:** Missing rate limiting on sensitive public endpoints (e.g. Opt-out).
+**Learning:** Without dedicated infrastructure (Redis), rate limiting can be effectively implemented using existing log tables (like `#__crm_email_optout`) by counting recent entries by IP.
+**Prevention:** Use `checkRateLimit($ip)` pattern in controllers for public forms, querying the log table for `COUNT(id)` where `ip = :ip` and `created > NOW - interval`.

--- a/com_crm/site/controllers/optout.php
+++ b/com_crm/site/controllers/optout.php
@@ -61,6 +61,15 @@ class CrmControllerOptout extends JControllerLegacy
             jexit(JText::_('JINVALID_TOKEN'));
         }
 
+        $ip     = substr($input->server->getString('REMOTE_ADDR'), 0, 45);
+        $itemid = $input->getInt('Itemid', $this->getDefaultItemid());
+
+        // Security: Rate Limit check (10 requests / hour)
+        if (!$this->checkRateLimit($ip)) {
+            $this->redirectWithMessage(JText::_('COM_CRM_OPTOUT_TOO_MANY_REQUESTS'), 'error', $itemid);
+            return;
+        }
+
         $email      = trim($input->getString('email'));
         $scope      = $input->getWord('scope', 'global');
         $campanhaId = $input->getString('campanha_id');
@@ -179,5 +188,32 @@ class CrmControllerOptout extends JControllerLegacy
         $app = JFactory::getApplication();
         $app->enqueueMessage($message, $type);
         $app->redirect(JRoute::_('index.php?Itemid=' . (int) $itemid, false));
+    }
+
+    /**
+     * Check rate limit for Opt-out requests.
+     * Limit: 10 requests per hour per IP.
+     *
+     * @param   string  $ip  The IP address.
+     *
+     * @return  boolean  True if allowed, False if limit exceeded.
+     */
+    protected function checkRateLimit($ip)
+    {
+        $db = JFactory::getDbo();
+        $date = JFactory::getDate();
+        $date->modify('-1 hour');
+        $dbDate = $db->quote($date->toSql());
+
+        $query = $db->getQuery(true)
+            ->select('COUNT(id)')
+            ->from($db->quoteName('#__crm_email_optout'))
+            ->where($db->quoteName('ip') . ' = ' . $db->quote($ip))
+            ->where($db->quoteName('created') . ' > ' . $dbDate);
+
+        $db->setQuery($query);
+        $count = (int) $db->loadResult();
+
+        return $count < 10;
     }
 }

--- a/com_crm/site/language/en-GB/en-GB.com_crm.ini
+++ b/com_crm/site/language/en-GB/en-GB.com_crm.ini
@@ -12,6 +12,7 @@ COM_CRM_LINK_INVALID_PROTOCOL="Invalid link."
 COM_CRM_OPTOUT_EMAIL_REQUIRED="Email address is required to unsubscribe."
 COM_CRM_OPTOUT_SUCCESS="You have been unsubscribed successfully."
 COM_CRM_OPTOUT_ERROR="We could not process your unsubscribe request. Please try again."
+COM_CRM_OPTOUT_TOO_MANY_REQUESTS="You are submitting too many requests. Please try again later."
 
 COM_CRM_OPTOUT_CONFIRM_TITLE="Unsubscribe Confirmation"
 COM_CRM_OPTOUT_CONFIRM_MESSAGE="Are you sure you want to unsubscribe %s?"

--- a/com_crm/site/language/pt-BR/pt-BR.com_crm.ini
+++ b/com_crm/site/language/pt-BR/pt-BR.com_crm.ini
@@ -13,6 +13,7 @@ COM_CRM_OPTOUT_EMAIL_REQUIRED="Informe o e-mail para concluir o descadastro."
 COM_CRM_OPTOUT_EMAIL_INVALID="O endereço de e-mail fornecido é inválido."
 COM_CRM_OPTOUT_SUCCESS="Descadastro realizado com sucesso."
 COM_CRM_OPTOUT_ERROR="Não foi possível processar o descadastro. Tente novamente."
+COM_CRM_OPTOUT_TOO_MANY_REQUESTS="Você está enviando muitas solicitações. Tente novamente mais tarde."
 
 COM_CRM_OPTOUT_CONFIRM_TITLE="Confirmação de Cancelamento"
 COM_CRM_OPTOUT_CONFIRM_MESSAGE="Tem certeza que deseja cancelar a inscrição de %s?"

--- a/tests/verify_optout_ratelimit.php
+++ b/tests/verify_optout_ratelimit.php
@@ -1,0 +1,33 @@
+<?php
+// tests/verify_optout_ratelimit.php
+
+$controllerFile = __DIR__ . '/../com_crm/site/controllers/optout.php';
+
+if (!file_exists($controllerFile)) {
+    echo "Error: optout.php not found at $controllerFile\n";
+    exit(1);
+}
+
+$content = file_get_contents($controllerFile);
+
+// Check if checkRateLimit method definition exists
+if (strpos($content, 'protected function checkRateLimit($ip)') === false) {
+    echo "FAILURE: Method checkRateLimit not defined in optout.php\n";
+    exit(1);
+}
+
+// Check if checkRateLimit is called inside unsubscribe
+// We look for the call logic roughly
+if (strpos($content, '$this->checkRateLimit($ip)') === false) {
+    echo "FAILURE: Method checkRateLimit is not called in optout.php\n";
+    exit(1);
+}
+
+// Check if it handles the return value (redirect or error)
+if (strpos($content, 'COM_CRM_OPTOUT_TOO_MANY_REQUESTS') === false) {
+    echo "FAILURE: Error message COM_CRM_OPTOUT_TOO_MANY_REQUESTS is not used.\n";
+    exit(1);
+}
+
+echo "SUCCESS: Rate limiting logic appears to be present in optout.php.\n";
+exit(0);


### PR DESCRIPTION
Implemented IP-based rate limiting on the `optout` controller.
- Added `checkRateLimit` method to `CrmControllerOptout`.
- Enforced limit of 10 requests per hour per IP.
- Added `COM_CRM_OPTOUT_TOO_MANY_REQUESTS` language key in en-GB and pt-BR.
- Reverted accidental changes to `composer.lock`.
- Added verification script.

---
*PR created automatically by Jules for task [1376265512829659905](https://jules.google.com/task/1376265512829659905) started by @jorgedemetrio*