### PR TITLE
🛡️ Sentinel: Fix IP Validation in Tracking Controllers

### DIFF
--- a/com_crm/site/controllers/link.php
+++ b/com_crm/site/controllers/link.php
@@ -67,7 +67,7 @@ class CrmControllerLink extends JControllerLegacy
 
         $sessionId = $session->getId();
         $ip = substr($input->server->getString('REMOTE_ADDR'), 0, 45);
-        $ipProxy = substr($input->server->getString('HTTP_X_FORWARDED_FOR'), 0, 45);
+        $ipProxy = $this->getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userAgent = substr($input->server->getString('HTTP_USER_AGENT'), 0, 255);
 
         if (empty($linkId)) {
@@ -198,5 +198,32 @@ class CrmControllerLink extends JControllerLegacy
         $app = JFactory::getApplication();
         $app->enqueueMessage($message, $type);
         $app->redirect(JRoute::_('index.php?Itemid=' . (int) $itemid, false));
+    }
+
+    /**
+     * Parse and validate HTTP_X_FORWARDED_FOR header.
+     *
+     * @param   string  $header  The HTTP header value.
+     *
+     * @return  string  The first valid IP address found, or empty string.
+     */
+    private function getValidProxyIp($header)
+    {
+        $ipProxy = '';
+
+        if (!empty($header)) {
+            $parts = explode(',', $header);
+
+            foreach ($parts as $part) {
+                $part = trim($part);
+
+                if (filter_var($part, FILTER_VALIDATE_IP)) {
+                    $ipProxy = $part;
+                    break;
+                }
+            }
+        }
+
+        return substr($ipProxy, 0, 45);
     }
 }

--- a/com_crm/site/controllers/optout.php
+++ b/com_crm/site/controllers/optout.php
@@ -82,7 +82,7 @@ class CrmControllerOptout extends JControllerLegacy
         $tracking   = substr($tracking, 0, 36);
         $sessionId  = $session->getId();
         $ip         = substr($input->server->getString('REMOTE_ADDR'), 0, 45);
-        $ipProxy    = substr($input->server->getString('HTTP_X_FORWARDED_FOR'), 0, 45);
+        $ipProxy    = $this->getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userId     = (int) JFactory::getUser()->id;
 
         if (empty($email)) {
@@ -179,5 +179,32 @@ class CrmControllerOptout extends JControllerLegacy
         $app = JFactory::getApplication();
         $app->enqueueMessage($message, $type);
         $app->redirect(JRoute::_('index.php?Itemid=' . (int) $itemid, false));
+    }
+
+    /**
+     * Parse and validate HTTP_X_FORWARDED_FOR header.
+     *
+     * @param   string  $header  The HTTP header value.
+     *
+     * @return  string  The first valid IP address found, or empty string.
+     */
+    private function getValidProxyIp($header)
+    {
+        $ipProxy = '';
+
+        if (!empty($header)) {
+            $parts = explode(',', $header);
+
+            foreach ($parts as $part) {
+                $part = trim($part);
+
+                if (filter_var($part, FILTER_VALIDATE_IP)) {
+                    $ipProxy = $part;
+                    break;
+                }
+            }
+        }
+
+        return substr($ipProxy, 0, 45);
     }
 }

--- a/com_crm/site/controllers/tracking.php
+++ b/com_crm/site/controllers/tracking.php
@@ -47,7 +47,7 @@ class CrmControllerTracking extends JControllerLegacy
 
         $sessionId  = $session->getId();
         $ip         = substr($input->server->getString('REMOTE_ADDR'), 0, 45);
-        $ipProxy    = substr($input->server->getString('HTTP_X_FORWARDED_FOR'), 0, 45);
+        $ipProxy    = $this->getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userAgent  = substr($input->server->getString('HTTP_USER_AGENT'), 0, 255);
 
         try {
@@ -122,5 +122,32 @@ class CrmControllerTracking extends JControllerLegacy
         $app->setHeader('Content-Type', 'image/gif');
         echo base64_decode('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
         $app->close();
+    }
+
+    /**
+     * Parse and validate HTTP_X_FORWARDED_FOR header.
+     *
+     * @param   string  $header  The HTTP header value.
+     *
+     * @return  string  The first valid IP address found, or empty string.
+     */
+    private function getValidProxyIp($header)
+    {
+        $ipProxy = '';
+
+        if (!empty($header)) {
+            $parts = explode(',', $header);
+
+            foreach ($parts as $part) {
+                $part = trim($part);
+
+                if (filter_var($part, FILTER_VALIDATE_IP)) {
+                    $ipProxy = $part;
+                    break;
+                }
+            }
+        }
+
+        return substr($ipProxy, 0, 45);
     }
 }

--- a/tests/test_ip_logic.php
+++ b/tests/test_ip_logic.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Test script for IP Proxy validation logic.
+ *
+ * This script isolates the logic intended for the controller method `getValidProxyIp`
+ * and verifies it against various input scenarios.
+ */
+
+function getValidProxyIp($header)
+{
+    $ipProxy = '';
+    if (!empty($header)) {
+        // Explode by comma to handle multiple proxies
+        $parts = explode(',', $header);
+        foreach ($parts as $part) {
+            $part = trim($part);
+            // Validate that it is a valid IP address
+            if (filter_var($part, FILTER_VALIDATE_IP)) {
+                $ipProxy = $part;
+                break; // Use the first valid IP found
+            }
+        }
+    }
+    // Truncate to database limits (45 chars) to prevent errors/DoS
+    return substr($ipProxy, 0, 45);
+}
+
+$tests = [
+    'Single IPv4' => [
+        'input' => '192.168.1.1',
+        'expected' => '192.168.1.1'
+    ],
+    'Multiple IPv4' => [
+        'input' => '10.0.0.1, 192.168.1.1',
+        'expected' => '10.0.0.1'
+    ],
+    'Multiple IPv4 with spaces' => [
+        'input' => ' 10.0.0.1 , 192.168.1.1 ',
+        'expected' => '10.0.0.1'
+    ],
+    'IPv6' => [
+        'input' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        'expected' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    ],
+    'Invalid first, valid second' => [
+        'input' => 'unknown, 192.168.1.1',
+        'expected' => '192.168.1.1'
+    ],
+    'All invalid' => [
+        'input' => 'unknown, invalid',
+        'expected' => ''
+    ],
+    'Empty' => [
+        'input' => '',
+        'expected' => ''
+    ],
+    'XSS Attempt' => [
+        'input' => '<script>alert(1)</script>',
+        'expected' => ''
+    ],
+    'Long Garbage' => [
+        'input' => str_repeat('a', 100),
+        'expected' => ''
+    ],
+    'Valid but too long (impossible for valid IP but good for truncation test)' => [
+        // IPs max out at 45 chars (IPv6 mapped), so truncation shouldn't really cut a valid IP
+        // But if we simulate a weird case where logic fails to validate but we want to ensure truncation
+        // Wait, logic validates IP, so it shouldn't return a long string unless it's a valid IP.
+        // Let's just test that the output is always <= 45 chars even if validation was skipped (hypothetically)
+        // Actually, let's test a valid IP that is exactly 45 chars (IPv4-mapped IPv6 can be long)
+        // 0000:0000:0000:0000:0000:ffff:192.168.100.228 is 45 chars
+        'input' => '0000:0000:0000:0000:0000:ffff:192.168.100.228',
+        'expected' => '0000:0000:0000:0000:0000:ffff:192.168.100.228'
+    ]
+];
+
+$failed = 0;
+
+foreach ($tests as $name => $data) {
+    $result = getValidProxyIp($data['input']);
+    if ($result !== $data['expected']) {
+        echo "FAILED: $name\n";
+        echo "  Input: '{$data['input']}'\n";
+        echo "  Expected: '{$data['expected']}'\n";
+        echo "  Got: '$result'\n";
+        $failed++;
+    } else {
+        echo "PASSED: $name\n";
+    }
+}
+
+if ($failed > 0) {
+    echo "\n$failed tests failed.\n";
+    exit(1);
+}
+
+echo "\nAll tests passed.\n";
+exit(0);


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix IP Validation/Spoofing Vulnerability

**Vulnerability:** The application was naively truncating the `HTTP_X_FORWARDED_FOR` header using `substr()` without validation. This allowed attackers to potentially spoof their IP address by sending a malformed header or appending garbage, and potentially inject invalid data into the database (though SQL injection was prevented by `quote()`).

**Fix:** Implemented a `getValidProxyIp` method that:
1. Explodes the header by comma to handle multiple proxies.
2. Iterates through the IPs and validates them using `filter_var(..., FILTER_VALIDATE_IP)`.
3. Returns the first valid IP found.
4. Truncates the result to 45 characters (database schema limit) as a final safety measure.

**Verification:**
- Created `tests/test_ip_logic.php` covering edge cases (multiple IPs, invalid IPs, XSS payloads).
- Static analysis checked with `phpstan`.
- Applied to `tracking.php`, `link.php`, and `optout.php`.

---
*PR created automatically by Jules for task [2203075420516240002](https://jules.google.com/task/2203075420516240002) started by @jorgedemetrio*