### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing getValidProxyIp in Opt-out controller

### DIFF
--- a/com_crm/site/controllers/optout.php
+++ b/com_crm/site/controllers/optout.php
@@ -216,4 +216,31 @@ class CrmControllerOptout extends JControllerLegacy
 
         return $count < 10;
     }
+
+    /**
+     * Parse and validate HTTP_X_FORWARDED_FOR header.
+     *
+     * @param   string  $header  The HTTP header value.
+     *
+     * @return  string  The first valid IP address found, or empty string.
+     */
+    private function getValidProxyIp($header)
+    {
+        $ipProxy = '';
+
+        if (!empty($header)) {
+            $parts = explode(',', $header);
+
+            foreach ($parts as $part) {
+                $part = trim($part);
+
+                if (filter_var($part, FILTER_VALIDATE_IP)) {
+                    $ipProxy = $part;
+                    break;
+                }
+            }
+        }
+
+        return substr($ipProxy, 0, 45);
+    }
 }


### PR DESCRIPTION
Severity: CRITICAL (Fatal Error / Security Gap)
Vulnerability: The `optout.php` controller called a non-existent method `getValidProxyIp`, causing fatal errors and skipping IP validation.
Fix: Added the missing method to the class.
Verification: Verified using reproduction script and static analysis.

---
*PR created automatically by Jules for task [6179781384639203886](https://jules.google.com/task/6179781384639203886) started by @jorgedemetrio*