### PR TITLE
🛡️ Sentinel: Centralize IP Validation Logic

### DIFF
--- a/com_crm/site/controllers/link.php
+++ b/com_crm/site/controllers/link.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+// Include Security Helper
+require_once JPATH_COMPONENT_SITE . '/helpers/security.php';
+
 jimport('joomla.application.component.controller');
 
 /**
@@ -67,7 +70,7 @@ class CrmControllerLink extends JControllerLegacy
 
         $sessionId = $session->getId();
         $ip = substr($input->server->getString('REMOTE_ADDR'), 0, 45);
-        $ipProxy = $this->getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
+        $ipProxy = CrmSecurityHelper::getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userAgent = substr($input->server->getString('HTTP_USER_AGENT'), 0, 255);
 
         if (empty($linkId)) {
@@ -198,32 +201,5 @@ class CrmControllerLink extends JControllerLegacy
         $app = JFactory::getApplication();
         $app->enqueueMessage($message, $type);
         $app->redirect(JRoute::_('index.php?Itemid=' . (int) $itemid, false));
-    }
-
-    /**
-     * Parse and validate HTTP_X_FORWARDED_FOR header.
-     *
-     * @param   string  $header  The HTTP header value.
-     *
-     * @return  string  The first valid IP address found, or empty string.
-     */
-    private function getValidProxyIp($header)
-    {
-        $ipProxy = '';
-
-        if (!empty($header)) {
-            $parts = explode(',', $header);
-
-            foreach ($parts as $part) {
-                $part = trim($part);
-
-                if (filter_var($part, FILTER_VALIDATE_IP)) {
-                    $ipProxy = $part;
-                    break;
-                }
-            }
-        }
-
-        return substr($ipProxy, 0, 45);
     }
 }

--- a/com_crm/site/controllers/optout.php
+++ b/com_crm/site/controllers/optout.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+// Include Security Helper
+require_once JPATH_COMPONENT_SITE . '/helpers/security.php';
+
 jimport('joomla.application.component.controller');
 
 /**
@@ -91,7 +94,7 @@ class CrmControllerOptout extends JControllerLegacy
         $tracking   = substr($tracking, 0, 36);
         $sessionId  = $session->getId();
         $ip         = substr($input->server->getString('REMOTE_ADDR'), 0, 45);
-        $ipProxy    = $this->getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
+        $ipProxy    = CrmSecurityHelper::getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userId     = (int) JFactory::getUser()->id;
 
         if (empty($email)) {
@@ -215,32 +218,5 @@ class CrmControllerOptout extends JControllerLegacy
         $count = (int) $db->loadResult();
 
         return $count < 10;
-    }
-
-    /**
-     * Parse and validate HTTP_X_FORWARDED_FOR header.
-     *
-     * @param   string  $header  The HTTP header value.
-     *
-     * @return  string  The first valid IP address found, or empty string.
-     */
-    private function getValidProxyIp($header)
-    {
-        $ipProxy = '';
-
-        if (!empty($header)) {
-            $parts = explode(',', $header);
-
-            foreach ($parts as $part) {
-                $part = trim($part);
-
-                if (filter_var($part, FILTER_VALIDATE_IP)) {
-                    $ipProxy = $part;
-                    break;
-                }
-            }
-        }
-
-        return substr($ipProxy, 0, 45);
     }
 }

--- a/com_crm/site/controllers/tracking.php
+++ b/com_crm/site/controllers/tracking.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+// Include Security Helper
+require_once JPATH_COMPONENT_SITE . '/helpers/security.php';
+
 jimport('joomla.application.component.controller');
 
 /**
@@ -47,7 +50,7 @@ class CrmControllerTracking extends JControllerLegacy
 
         $sessionId  = $session->getId();
         $ip         = substr($input->server->getString('REMOTE_ADDR'), 0, 45);
-        $ipProxy    = $this->getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
+        $ipProxy    = CrmSecurityHelper::getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userAgent  = substr($input->server->getString('HTTP_USER_AGENT'), 0, 255);
 
         try {
@@ -122,32 +125,5 @@ class CrmControllerTracking extends JControllerLegacy
         $app->setHeader('Content-Type', 'image/gif');
         echo base64_decode('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
         $app->close();
-    }
-
-    /**
-     * Parse and validate HTTP_X_FORWARDED_FOR header.
-     *
-     * @param   string  $header  The HTTP header value.
-     *
-     * @return  string  The first valid IP address found, or empty string.
-     */
-    private function getValidProxyIp($header)
-    {
-        $ipProxy = '';
-
-        if (!empty($header)) {
-            $parts = explode(',', $header);
-
-            foreach ($parts as $part) {
-                $part = trim($part);
-
-                if (filter_var($part, FILTER_VALIDATE_IP)) {
-                    $ipProxy = $part;
-                    break;
-                }
-            }
-        }
-
-        return substr($ipProxy, 0, 45);
     }
 }

--- a/com_crm/site/helpers/index.html
+++ b/com_crm/site/helpers/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/com_crm/site/helpers/security.php
+++ b/com_crm/site/helpers/security.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_crm
+ *
+ * @copyright   Copyright (C) 2024 Sobieski Produções. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Crm Security Helper.
+ * Centralizes security-related logic for the site component.
+ *
+ * @since  1.0.0
+ */
+class CrmSecurityHelper
+{
+    /**
+     * Parse and validate HTTP_X_FORWARDED_FOR header.
+     *
+     * @param   string  $header  The HTTP header value.
+     *
+     * @return  string  The first valid IP address found, or empty string.
+     */
+    public static function getValidProxyIp($header)
+    {
+        $ipProxy = '';
+
+        if (!empty($header)) {
+            $parts = explode(',', $header);
+
+            foreach ($parts as $part) {
+                $part = trim($part);
+
+                if (filter_var($part, FILTER_VALIDATE_IP)) {
+                    $ipProxy = $part;
+                    break;
+                }
+            }
+        }
+
+        return substr($ipProxy, 0, 45);
+    }
+}

--- a/tests/test_ip_logic.php
+++ b/tests/test_ip_logic.php
@@ -6,24 +6,11 @@
  * and verifies it against various input scenarios.
  */
 
-function getValidProxyIp($header)
-{
-    $ipProxy = '';
-    if (!empty($header)) {
-        // Explode by comma to handle multiple proxies
-        $parts = explode(',', $header);
-        foreach ($parts as $part) {
-            $part = trim($part);
-            // Validate that it is a valid IP address
-            if (filter_var($part, FILTER_VALIDATE_IP)) {
-                $ipProxy = $part;
-                break; // Use the first valid IP found
-            }
-        }
-    }
-    // Truncate to database limits (45 chars) to prevent errors/DoS
-    return substr($ipProxy, 0, 45);
-}
+// Define JEXEC to allow inclusion of the helper
+define('_JEXEC', 1);
+
+// Include the helper
+require_once dirname(__DIR__) . '/com_crm/site/helpers/security.php';
 
 $tests = [
     'Single IPv4' => [
@@ -77,7 +64,8 @@ $tests = [
 $failed = 0;
 
 foreach ($tests as $name => $data) {
-    $result = getValidProxyIp($data['input']);
+    // Use the helper method
+    $result = CrmSecurityHelper::getValidProxyIp($data['input']);
     if ($result !== $data['expected']) {
         echo "FAILED: $name\n";
         echo "  Input: '{$data['input']}'\n";


### PR DESCRIPTION
🛡️ Sentinel: Centralize IP Validation Logic

Refactored the duplicate `getValidProxyIp` method found in multiple site controllers (`tracking.php`, `link.php`, `optout.php`) into a shared helper class `CrmSecurityHelper`.

**Security Enhancement:**
- Eliminates code duplication for security-critical logic (DRY).
- Ensures consistent IP validation and sanitization across the application.
- Simplifies future updates to IP handling logic (e.g., trusted proxies).

**Changes:**
- Added `com_crm/site/helpers/security.php`
- Added `com_crm/site/helpers/index.html`
- Modified `com_crm/site/controllers/tracking.php`
- Modified `com_crm/site/controllers/link.php`
- Modified `com_crm/site/controllers/optout.php`
- Updated `tests/test_ip_logic.php`

**Verification:**
- Ran `tests/test_ip_logic.php` (All tests passed).
- Verified syntax of modified controllers.

---
*PR created automatically by Jules for task [7194133869364436090](https://jules.google.com/task/7194133869364436090) started by @jorgedemetrio*