### PR TITLE
🛡️ Sentinel: [ENHANCEMENT] Add rate limiting to public tracking endpoints

### DIFF
--- a/com_crm/site/controllers/link.php
+++ b/com_crm/site/controllers/link.php
@@ -73,6 +73,12 @@ class CrmControllerLink extends JControllerLegacy
         $ipProxy = CrmSecurityHelper::getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userAgent = substr($input->server->getString('HTTP_USER_AGENT'), 0, 255);
 
+        // Security: Rate Limit check (20 clicks/min)
+        if (!CrmSecurityHelper::checkRateLimit('#__crm_campanha_link_clicks', 'clicked_at', $ip, 20, 1)) {
+            $this->redirectWithMessage(JText::_('COM_CRM_LINK_TOO_MANY_REQUESTS'), 'error', $itemid);
+            return;
+        }
+
         if (empty($linkId)) {
             $this->redirectWithMessage(JText::_('COM_CRM_LINK_MISSING'), 'error', $itemid);
             return;

--- a/com_crm/site/controllers/optout.php
+++ b/com_crm/site/controllers/optout.php
@@ -68,7 +68,7 @@ class CrmControllerOptout extends JControllerLegacy
         $itemid = $input->getInt('Itemid', $this->getDefaultItemid());
 
         // Security: Rate Limit check (10 requests / hour)
-        if (!$this->checkRateLimit($ip)) {
+        if (!CrmSecurityHelper::checkRateLimit('#__crm_email_optout', 'created', $ip, 10, 60)) {
             $this->redirectWithMessage(JText::_('COM_CRM_OPTOUT_TOO_MANY_REQUESTS'), 'error', $itemid);
             return;
         }
@@ -193,30 +193,4 @@ class CrmControllerOptout extends JControllerLegacy
         $app->redirect(JRoute::_('index.php?Itemid=' . (int) $itemid, false));
     }
 
-    /**
-     * Check rate limit for Opt-out requests.
-     * Limit: 10 requests per hour per IP.
-     *
-     * @param   string  $ip  The IP address.
-     *
-     * @return  boolean  True if allowed, False if limit exceeded.
-     */
-    protected function checkRateLimit($ip)
-    {
-        $db = JFactory::getDbo();
-        $date = JFactory::getDate();
-        $date->modify('-1 hour');
-        $dbDate = $db->quote($date->toSql());
-
-        $query = $db->getQuery(true)
-            ->select('COUNT(id)')
-            ->from($db->quoteName('#__crm_email_optout'))
-            ->where($db->quoteName('ip') . ' = ' . $db->quote($ip))
-            ->where($db->quoteName('created') . ' > ' . $dbDate);
-
-        $db->setQuery($query);
-        $count = (int) $db->loadResult();
-
-        return $count < 10;
-    }
 }

--- a/com_crm/site/controllers/tracking.php
+++ b/com_crm/site/controllers/tracking.php
@@ -53,6 +53,14 @@ class CrmControllerTracking extends JControllerLegacy
         $ipProxy    = CrmSecurityHelper::getValidProxyIp($input->server->getString('HTTP_X_FORWARDED_FOR'));
         $userAgent  = substr($input->server->getString('HTTP_USER_AGENT'), 0, 255);
 
+        // Security: Rate Limit check to prevent database exhaustion (60 opens/min)
+        if (!CrmSecurityHelper::checkRateLimit('#__crm_email_opens', 'opened_at', $ip, 60, 1)) {
+            // Rate limit exceeded. Return 1x1 GIF immediately to fail silently.
+            $app->setHeader('Content-Type', 'image/gif');
+            echo base64_decode('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+            $app->close();
+        }
+
         try {
             // Security: Prevent IDOR by requiring validation that envio_id belongs to campanha_id.
             // If campanha_id is not provided, we DO NOT look it up automatically, to force the attacker to know the UUID.

--- a/com_crm/site/helpers/security.php
+++ b/com_crm/site/helpers/security.php
@@ -43,4 +43,34 @@ class CrmSecurityHelper
 
         return substr($ipProxy, 0, 45);
     }
+
+    /**
+     * Check rate limit for a specific action/table.
+     *
+     * @param   string   $table           Table name (e.g. #__crm_email_opens).
+     * @param   string   $dateColumn      Column name for timestamp (e.g. opened_at).
+     * @param   string   $ip              IP address to check.
+     * @param   integer  $limit           Max allowed requests.
+     * @param   integer  $intervalMinutes Time interval in minutes.
+     *
+     * @return  boolean  True if allowed, False if limit exceeded.
+     */
+    public static function checkRateLimit($table, $dateColumn, $ip, $limit = 60, $intervalMinutes = 1)
+    {
+        $db = JFactory::getDbo();
+        $date = JFactory::getDate();
+        $date->modify("-{$intervalMinutes} minutes");
+        $dbDate = $db->quote($date->toSql());
+
+        $query = $db->getQuery(true)
+            ->select('COUNT(id)')
+            ->from($db->quoteName($table))
+            ->where($db->quoteName('ip') . ' = ' . $db->quote($ip))
+            ->where($db->quoteName($dateColumn) . ' > ' . $dbDate);
+
+        $db->setQuery($query);
+        $count = (int) $db->loadResult();
+
+        return $count < $limit;
+    }
 }

--- a/com_crm/site/language/pt-BR/pt-BR.com_crm.ini
+++ b/com_crm/site/language/pt-BR/pt-BR.com_crm.ini
@@ -23,3 +23,4 @@ COM_CRM_OPTOUT_HELP_BODY="Esta tela solicita sua confirmação para garantir que
 COM_CRM_OPTOUT_VIEW_DEFAULT_TITLE="Página de Cancelamento"
 COM_CRM_OPTOUT_VIEW_DEFAULT_OPTION="Página de Cancelamento"
 COM_CRM_OPTOUT_VIEW_DEFAULT_DESC="Exibe a página de confirmação de cancelamento."
+COM_CRM_LINK_TOO_MANY_REQUESTS="Muitas solicitações detectadas. Por favor, aguarde alguns instantes."


### PR DESCRIPTION
🛡️ Sentinel: [ENHANCEMENT] Add rate limiting to public tracking endpoints

**🚨 Severity:** MEDIUM (Enhancement)

**💡 Vulnerability:** Public tracking endpoints (`link.php`, `tracking.php`) were susceptible to DoS or database exhaustion attacks due to lack of rate limiting. An attacker could flood these endpoints to fill the database with log entries (`#__crm_campanha_link_clicks`, `#__crm_email_opens`).

**🎯 Impact:**
- Database storage exhaustion.
- Analytics skewing.
- Potential performance degradation.

**🔧 Fix:**
- Implemented `CrmSecurityHelper::checkRateLimit` to centralize rate limiting logic using existing activity tables.
- Applied 60 requests/minute limit to `tracking.php` (returning 1x1 GIF on failure).
- Applied 20 requests/minute limit to `link.php` (redirecting with error on failure).
- Refactored `optout.php` to use the shared helper.

**✅ Verification:**
- Verified query logic using a standalone mock script (`tests/verify_rate_limit.php`).
- Confirmed logic handles database queries correctly.
- Confirmed syntax validity.

---
*PR created automatically by Jules for task [5992555133490176427](https://jules.google.com/task/5992555133490176427) started by @jorgedemetrio*